### PR TITLE
Update deprecated property [artifactId] into [project.artifactId]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
               <version>3.4.0</version>
             </plugin>
           </plugins>        
-        <finalName>${artifactId}</finalName>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
There's a _maven_ warning about using **deprecated** _${artifactId}_ expression, which suggests upgrading it to _${project.artifactId}_
```
$ mvn clean
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for airhacks:jakartaee-essentials:war:10.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] -------------------< airhacks:jakartaee-essentials >--------------------
[INFO] Building jakartaee-essentials 10.0
[INFO]   from pom.xml
[INFO] --------------------------------[ war ]---------------------------------
[INFO]
[INFO] --- clean:3.2.0:clean (default-clean) @ jakartaee-essentials ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.228 s
[INFO] Finished at: 2024-12-28T11:37:26+01:00
[INFO] ------------------------------------------------------------------------